### PR TITLE
Sort tags alphabetically and truncate long links

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2173,7 +2173,7 @@ class EisenMatrixController {
             const collapsedClass = isCollapsed ? ' collapsed' : '';
 
             const tagsHTML = task.labels && task.labels.length > 0
-                ? `<div class="task-tags">${task.labels.map(l => {
+                ? `<div class="task-tags">${[...task.labels].sort((a, b) => a.localeCompare(b)).map(l => {
                     const bg = tagColors[l];
                     const style = bg ? ` style="background-color: ${bg}; color: ${this.getTagTextColor(bg)}"` : '';
                     return `<span class="task-tag"${style}>${this.escapeHTML(l)}</span>`;
@@ -2618,7 +2618,7 @@ class EisenMatrixController {
 
         const tagColors = this.getTagColors();
         const tagsHTML = task.labels.length > 0
-            ? `<div class="task-tags">${task.labels.map(label => {
+            ? `<div class="task-tags">${[...task.labels].sort((a, b) => a.localeCompare(b)).map(label => {
                 const bg = tagColors[label];
                 const style = bg ? ` style="background-color: ${bg}; color: ${this.getTagTextColor(bg)}"` : '';
                 return `<span class="task-tag"${style}>${this.escapeHTML(label)}</span>`;
@@ -2807,7 +2807,7 @@ class EisenMatrixController {
 
         const tagColors = this.getTagColors();
         const tagsHTML = task.labels.length > 0
-            ? `<div class="task-tags">${task.labels.map(label => {
+            ? `<div class="task-tags">${[...task.labels].sort((a, b) => a.localeCompare(b)).map(label => {
                 const bg = tagColors[label];
                 const style = bg ? ` style="background-color: ${bg}; color: ${this.getTagTextColor(bg)}"` : '';
                 return `<span class="task-tag"${style}>${this.escapeHTML(label)}</span>`;

--- a/src/styles.css
+++ b/src/styles.css
@@ -711,7 +711,10 @@ body {
     border-bottom: 2px solid var(--accent-electric);
     display: inline-block;
     transition: all 0.15s ease;
-    word-break: break-all;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .task-link:hover {


### PR DESCRIPTION
## Changes

### Tags rendered in alphabetical order
All tag rendering locations (matrix cards, backlog, archive) now sort `task.labels` alphabetically via `[...task.labels].sort((a, b) => a.localeCompare(b))` before mapping to HTML. The settings panel already sorted tags.

### Long links truncated instead of wrapping
Replaced `word-break: break-all` on `.task-link` with `overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%` so long URLs are truncated with an ellipsis instead of breaking onto new lines.

## Testing
All 109 existing tests pass.