### PR TITLE
Fix text-overflow ellipsis for task links in flex container

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -712,7 +712,6 @@ body {
     display: inline-block;
     transition: all 0.15s ease;
     max-width: 100%;
-    width: 100%;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/styles.css
+++ b/src/styles.css
@@ -712,6 +712,8 @@ body {
     display: inline-block;
     transition: all 0.15s ease;
     max-width: 100%;
+    width: 100%;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
Follow-up to #18 — addresses [review feedback](https://github.com/mbianchidev/eisen-todo/pull/18) about `text-overflow: ellipsis` not reliably working inside a flex column.

### Fix
Added `min-width: 0` and `width: 100%` to `.task-link` so the flex item can shrink below its min-content width and the ellipsis truncation reliably kicks in for long URLs.

### Testing
All 109 tests pass.